### PR TITLE
Lockable surveys

### DIFF
--- a/server/admin.js
+++ b/server/admin.js
@@ -115,6 +115,7 @@ router.get('/results/:id', async (req, res, next) => {
     title: definition.data.title,
     note: definition.data.note,
     tables: getResults(results, definition),
+    locked: definition.locked,
   })
 })
 

--- a/server/admin.js
+++ b/server/admin.js
@@ -54,6 +54,14 @@ router.post('/create', async (req, res) => {
   res.json({id: test[0]})
 })
 
+router.post('/lock', async (req, res) => {
+  await db('surveys')
+    .where('id', req.body.id)
+    .update({locked: req.body.locked})
+    .returning('id')
+  res.sendStatus(200)
+})
+
 router.get('/surveys', async (req, res, next) => {
   res.json(await db('surveys'))
 })

--- a/server/api.js
+++ b/server/api.js
@@ -18,6 +18,14 @@ router.get('/survey/:id', async (req, res, next) => {
 })
 
 router.post('/submit/:id', async (req, res, next) => {
+  const {locked} = await db('surveys')
+    .select('locked')
+    .where('id', req.params.id)
+    .first()
+  if (locked) {
+    res.sendStatus(403)
+    return
+  }
   const test = await db('results')
     .insert({
       created_at: new Date().toISOString(),

--- a/server/api.js
+++ b/server/api.js
@@ -14,7 +14,7 @@ router.get('/survey/:id', async (req, res, next) => {
     .select('*')
     .where('id', req.params.id)
     .first()
-  res.json({id: dbData.id, created_at: dbData.created_at, ...dbData.data})
+  res.json({id: dbData.id, created_at: dbData.created_at, locked: dbData.locked, ...dbData.data})
 })
 
 router.post('/submit/:id', async (req, res, next) => {

--- a/server/migrations/20181025111317_add_locked_to_surveys.js
+++ b/server/migrations/20181025111317_add_locked_to_surveys.js
@@ -1,0 +1,15 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('surveys', (table) => {
+      table.boolean('locked').defaultTo(false)
+    }),
+  ])
+}
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('surveys', (table) => {
+      table.dropColumn('locked')
+    }),
+  ])
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -260,3 +260,28 @@ export const submitSurvey = (id, pushHistory) => async (dispatch, getState) => {
     console.log(e)
   }
 }
+
+export const updateLocked = (id, locked) => async (dispatch, getState) => {
+  try {
+    const res = await fetch(`${process.env.REACT_APP_API_URL || ''}/admin/lock`, {
+      method: 'POST',
+      headers: new Headers({
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-Token': window.localStorage.getItem('token'),
+      }),
+      body: JSON.stringify({
+        id,
+        locked,
+      }),
+    })
+    if (res.ok) {
+      dispatch(updateValue(['surveyList', id, 'locked'], locked))
+    } else {
+      console.log(res.status)
+      console.log(res.statusText)
+    }
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -76,7 +76,7 @@ export const loadOrClearSurvey = (path) => ({
     const saved = window.localStorage.getItem(path)
     const surveyToUse = saved ? JSON.parse(saved) : survey
     // always clear 'create' survey
-    if (path !== 'create' && saved) return JSON.parse(saved)
+    if (path !== 'create' && saved) return {...survey, ...JSON.parse(saved)}
     const tables = surveyToUse.tables.map((table) => {
       switch (table.type) {
         case 'header':

--- a/src/actions.js
+++ b/src/actions.js
@@ -276,7 +276,8 @@ export const updateLocked = (id, locked) => async (dispatch, getState) => {
       }),
     })
     if (res.ok) {
-      dispatch(updateValue(['surveyList', id, 'locked'], locked))
+      getState().surveyList[id] && dispatch(updateValue(['surveyList', id, 'locked'], locked))
+      getState().results[id] && dispatch(updateValue(['results', id, 'locked'], locked))
     } else {
       console.log(res.status)
       console.log(res.statusText)

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -50,6 +50,12 @@ const styles = (theme) => ({
   leftIcon: {
     marginRight: theme.spacing.unit,
   },
+  lockedTextContainer: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    color: 'red',
+    fontWeight: 'bold',
+  },
 })
 
 const Results = ({id, results, classes, saveCsv}) => {
@@ -67,8 +73,9 @@ const Results = ({id, results, classes, saveCsv}) => {
         <Typography variant="display2" gutterBottom>
           {title}
         </Typography>
-        <Typography gutterBottom>
-          <ToggleLocked locked={results.locked} surveyId={id} />
+        <Typography gutterBottom className={classes.lockedTextContainer}>
+          <ToggleLocked locked={results.locked} surveyId={id} /> Pre uzamknutý formulár nie je viac
+          možné pridávať odpovede. Odomknite kliknutím na zámok.
         </Typography>
         <Typography gutterBottom>Odkaz na dotazník: </Typography>
         <a href={`${window.location.origin}/survey/${id}`} className={classes.link}>

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -23,6 +23,7 @@ import Title from './Title'
 import Header from './Header'
 import Standard from './Standard'
 import Rectangular from './Rectangular'
+import ToggleLocked from './ToggleLocked'
 
 const styles = (theme) => ({
   root,
@@ -65,6 +66,9 @@ const Results = ({id, results, classes, saveCsv}) => {
       <Paper className={classes.paper}>
         <Typography variant="display2" gutterBottom>
           {title}
+        </Typography>
+        <Typography gutterBottom>
+          <ToggleLocked locked={results.locked} surveyId={id} />
         </Typography>
         <Typography gutterBottom>Odkaz na dotazník: </Typography>
         <a href={`${window.location.origin}/survey/${id}`} className={classes.link}>

--- a/src/components/Survey.js
+++ b/src/components/Survey.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 import {branch, withHandlers, withProps} from 'recompose'
 import {withRouter, Link, Route} from 'react-router-dom'
 import {withDataProviders} from 'data-provider'
-import {get} from 'lodash'
+import {omit} from 'lodash'
 import {submitSurvey, clearStoredData, loadOrClearSurvey} from '../actions'
 import {paramsOrCreateSelector} from '../selectors'
 import {surveyProvider} from '../dataProviders'
@@ -52,6 +52,12 @@ const styles = (theme) => ({
   printRoot: {
     margin: '20mm',
   },
+  lockedTextContainer: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    color: 'red',
+    fontWeight: 'bold',
+  },
 })
 
 class Survey extends React.Component {
@@ -70,7 +76,7 @@ class Survey extends React.Component {
   componentDidUpdate = () => {
     const id = paramsOrCreateSelector(undefined, this.props)
     if (!this.props.print && id !== 'create' && this.state.loaded) {
-      window.localStorage.setItem(id, JSON.stringify(this.props.data))
+      window.localStorage.setItem(id, JSON.stringify(omit(this.props.data, ['locked'])))
     }
     return null
   }
@@ -143,8 +149,13 @@ class Survey extends React.Component {
             {title}
           </Typography>
           {locked && (
-            <Typography title="Formulár je zamknutý" gutterBottom>
-              <Lock style={{color: 'red'}} />
+            <Typography
+              title="Formulár je zamknutý"
+              gutterBottom
+              className={classes.lockedTextContainer}
+            >
+              <Lock style={{color: 'red'}} /> Formulár je uzamknutý a nové odpovede už nie je možné
+              odoslať. Kontaktujte prosím správcu.
             </Typography>
           )}
           <Typography gutterBottom>{note}</Typography>

--- a/src/components/Survey.js
+++ b/src/components/Survey.js
@@ -84,7 +84,7 @@ class Survey extends React.Component {
         <div className={classes.root}>
           <Paper className={classes.paper}>
             <Typography variant="subheading" gutterBottom>
-              Ďakujeme za vyplnenie formulara
+              Ďakujeme za vyplnenie formulára
             </Typography>
             <ReactToPrint
               trigger={() => (
@@ -143,7 +143,7 @@ class Survey extends React.Component {
             {title}
           </Typography>
           {locked && (
-            <Typography title="Formular je zamknuty" gutterBottom>
+            <Typography title="Formulár je zamknutý" gutterBottom>
               <Lock style={{color: 'red'}} />
             </Typography>
           )}
@@ -181,7 +181,7 @@ class Survey extends React.Component {
                 color="primary"
                 className={classes.button}
                 onClick={submit}
-                title={locked && 'Formular je zamknuty'}
+                title={locked && 'Formulár je zamknutý'}
               >
                 {locked ? (
                   <Lock className={classes.leftIcon} />

--- a/src/components/Survey.js
+++ b/src/components/Survey.js
@@ -21,6 +21,7 @@ import Cancel from '@material-ui/icons/Cancel'
 import Typography from '@material-ui/core/Typography'
 import DownloadIcon from '@material-ui/icons/CloudDownload'
 import ArrowBack from '@material-ui/icons/ArrowBack'
+import Lock from '@material-ui/icons/Lock'
 import Header from './Header'
 import Standard from './Standard'
 import Rectangular from './Rectangular'
@@ -77,7 +78,7 @@ class Survey extends React.Component {
   render = () => {
     if (!this.state.loaded) return null
     const {path, data, classes, submit, deleteSurvey, preview, saveCsv, print} = this.props
-    const {tables, title, done, note} = data
+    const {tables, title, done, note, locked} = data
     if (done && !print) {
       return (
         <div className={classes.root}>
@@ -141,6 +142,11 @@ class Survey extends React.Component {
           <Typography variant="display2" gutterBottom>
             {title}
           </Typography>
+          {locked && (
+            <Typography title="Formular je zamknuty" gutterBottom>
+              <Lock style={{color: 'red'}} />
+            </Typography>
+          )}
           <Typography gutterBottom>{note}</Typography>
           {tables.map((t, i) => {
             const tablePath = `${path}.tables[${i}]`
@@ -175,8 +181,13 @@ class Survey extends React.Component {
                 color="primary"
                 className={classes.button}
                 onClick={submit}
+                title={locked && 'Formular je zamknuty'}
               >
-                <Send className={classes.leftIcon} />
+                {locked ? (
+                  <Lock className={classes.leftIcon} />
+                ) : (
+                  <Send className={classes.leftIcon} />
+                )}
                   Dokončiť formulár
               </Button>
             </div>

--- a/src/components/SurveyList.js
+++ b/src/components/SurveyList.js
@@ -15,6 +15,7 @@ import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Paper from '@material-ui/core/Paper'
 import InsertDriveFile from '@material-ui/icons/InsertDriveFile'
+import ToggleLocked from './ToggleLocked'
 
 const styles = (theme) => ({
   container: {
@@ -52,6 +53,7 @@ const SurveyList = ({data, classes}) => {
           <TableHead>
             <TableRow>
               <TableCell>Dátum</TableCell>
+              <TableCell>Status</TableCell>
               <TableCell>Názov</TableCell>
             </TableRow>
           </TableHead>
@@ -59,6 +61,9 @@ const SurveyList = ({data, classes}) => {
             {Object.values(data).map((row, i) => (
               <TableRow key={i}>
                 <TableCell>{new Date(row.created_at).toLocaleString()}</TableCell>
+                <TableCell>
+                  <ToggleLocked surveyId={row.id} locked={row.locked} />
+                </TableCell>
                 <TableCell>
                   <Link to={`/results/${row.id}`}>{row.data.title}</Link>
                 </TableCell>

--- a/src/components/SurveyList.js
+++ b/src/components/SurveyList.js
@@ -53,7 +53,7 @@ const SurveyList = ({data, classes}) => {
           <TableHead>
             <TableRow>
               <TableCell>Dátum</TableCell>
-              <TableCell>Status</TableCell>
+              <TableCell>Stav</TableCell>
               <TableCell>Názov</TableCell>
             </TableRow>
           </TableHead>

--- a/src/components/ToggleLocked.js
+++ b/src/components/ToggleLocked.js
@@ -8,11 +8,11 @@ import LockOpen from '@material-ui/icons/LockOpen'
 
 const ToggleLocked = ({surveyId, locked, toggleLocked}) =>
   locked ? (
-    <div className="clickable" title="Uzavrety" onClick={toggleLocked}>
+    <div className="clickable" title="Zamknutý" onClick={toggleLocked}>
       <Lock />
     </div>
   ) : (
-    <div className="clickable" title="Otvoreny" onClick={toggleLocked}>
+    <div className="clickable" title="Otvorený" onClick={toggleLocked}>
       <LockOpen />
     </div>
   )

--- a/src/components/ToggleLocked.js
+++ b/src/components/ToggleLocked.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import {compose} from 'redux'
+import {connect} from 'react-redux'
+import {withHandlers} from 'recompose'
+import {updateLocked} from '../actions'
+import Lock from '@material-ui/icons/Lock'
+import LockOpen from '@material-ui/icons/LockOpen'
+
+const ToggleLocked = ({surveyId, locked, toggleLocked}) =>
+  locked ? (
+    <div className="clickable" title="Uzavrety" onClick={toggleLocked}>
+      <Lock />
+    </div>
+  ) : (
+    <div className="clickable" title="Otvoreny" onClick={toggleLocked}>
+      <LockOpen />
+    </div>
+  )
+
+export default compose(
+  connect(
+    null,
+    {updateLocked}
+  ),
+  withHandlers({
+    toggleLocked: ({updateLocked, surveyId, locked}) => () => updateLocked(surveyId, !locked),
+  })
+)(ToggleLocked)

--- a/src/components/ToggleLocked.js
+++ b/src/components/ToggleLocked.js
@@ -8,11 +8,11 @@ import LockOpen from '@material-ui/icons/LockOpen'
 
 const ToggleLocked = ({surveyId, locked, toggleLocked}) =>
   locked ? (
-    <div className="clickable" title="Zamknutý" onClick={toggleLocked}>
+    <div className="clickable" style={{display: 'flex'}} title="Zamknutý" onClick={toggleLocked}>
       <Lock />
     </div>
   ) : (
-    <div className="clickable" title="Otvorený" onClick={toggleLocked}>
+    <div className="clickable" style={{display: 'flex'}} title="Otvorený" onClick={toggleLocked}>
       <LockOpen />
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,9 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+div.clickable {
+  width: min-content;
+  height: min-content;
+  cursor: pointer;
+}

--- a/src/state.js
+++ b/src/state.js
@@ -20,7 +20,8 @@ export const emptyStandard = {
 const getInitialState = () => ({
   resources: {},
   surveys: {},
-  surveyList: [],
+  surveyList: {},
+  results: {},
   create: {
     title: '',
     tables: [


### PR DESCRIPTION
Added column `locked` to surveys - represents whether the survey accepts new submissions.

Admin can change locked status of survey by clicking on lock icon(`ToggleLocked` component) from SurveysList or Survey
Creating already locked survey is probably low priority as admin can immediately lock survey after creation.
![image](https://user-images.githubusercontent.com/18385255/47508075-b4be2900-d873-11e8-831c-35f2f51db81e.png)
![image](https://user-images.githubusercontent.com/18385255/47508352-3ca43300-d874-11e8-8a4a-62e875725c55.png)
 User sees red lock icon and alternate of submit button in locked surveys
The submit button is still clickable (server ignores submissions into locked surveys) to support wider variety of use cases(I can elaborate)
![image](https://user-images.githubusercontent.com/18385255/47508787-04e9bb00-d875-11e8-8737-4b0bff9a581c.png)
